### PR TITLE
Update SweepWavelength for Stepped Sweeps for Compact TLS 

### DIFF
--- a/siepiclab/sequences/SweepWavelengthSpectrum/__init__.py
+++ b/siepiclab/sequences/SweepWavelengthSpectrum/__init__.py
@@ -116,7 +116,7 @@ class SweepWavelengthSpectrum(measurements.sequence):
         time.sleep(time_delays)
 
         # start the wavelength sweep
-        if verbose:
+        if self.verbose:
             print("***Starting Wavelength Sweep.***")
         self.tls.SetSweepRun(True)
         time.sleep(time_delays)
@@ -124,7 +124,7 @@ class SweepWavelengthSpectrum(measurements.sequence):
         while self.tls.GetSweepRun():
             time.sleep(time_delays)  # check every half a sec if the sweep is done
        
-        if verbose:
+        if self.verbose:
             print("***Sweep Finished, fetching.***")
         # fetch the sweep data from the buffers
         if self.mode.upper() == 'STEP':


### PR DESCRIPTION
HP81689A is a Compact TLS that does not have the physical equipment to do a Continuous Wavelength Sweep and can only do a Stepped Sweep. Rather than do a copy/paste for most of the settings in the Continuous Sweep sequence, I added the option to select which mode to use to reuse most of the functionality.

This is currently working for the 81689A TLS, it needs to be verified on the other larger TLS that do Continuous Sweeps.

Things of note:
- inputting mode as a parameter to the initialization (works but is better to have it as an attribute with functions?)
- extend the instrument list