### PR TITLE
Add LDC-SMU sequence + Fix SMU driver

### DIFF
--- a/siepiclab/drivers/smu_keithley2400/__init__.py
+++ b/siepiclab/drivers/smu_keithley2400/__init__.py
@@ -381,3 +381,31 @@ class smu_keithley2400(instruments.instr_VISA):
             self.SetResistanceMode(chan)
             res = float(self.addr.query("READ?"))
             return res
+
+
+
+
+
+    def GetBeeperState(self):
+        return self.addr.query(':SYST:BEEP:STATE?')
+    
+    def SetBeeperState(self, state):
+        if state == True:
+            self.addr.write(':SYST:BEEP:STATE ON')
+        elif state == False:
+            self.addr.write(':SYST:BEEP:STATE OFF')
+
+
+    def GetBeeperSettings(self):
+        # Cannot find from documentation.
+        pass
+
+    def SetBepperSettings(self, freq, time):
+        """
+        freq [65, 2e6]
+        time [0, 7.9]
+        
+        Doesn't control the Error Beeps
+        """
+
+        self.addr.write(f':SYST:BEEP:IMM {freq},{time}')

--- a/siepiclab/drivers/smu_keithley2400/__init__.py
+++ b/siepiclab/drivers/smu_keithley2400/__init__.py
@@ -21,12 +21,12 @@ class smu_keithley2400(instruments.instr_VISA):
         """Return an instance of the instrument."""
         currState = instruments.state()
         currState.AddState('output_a', self.GetOutput('A'))
-        currState.AddState('volt_a', self.GetVoltage('A'))
-        currState.AddState('curr_a', self.GetCurrent('A'))
-        currState.AddState('curr_lim_a', self.GetCurrentLimit('A'))
-        currState.AddState('volt_lim_a', self.GetVoltageLimit('A'))
-        currState.AddState('res_a', self.GetResistance('A'))
-
+        currState.AddState('auto_ohm_mode', self.GetAutoOhmMode())
+        #currState.AddState('volt_a', self.GetVoltage('A'))
+        #currState.AddState('curr_a', self.GetCurrent('A'))
+        #currState.AddState('curr_lim_a', self.GetCurrentLimit('A'))
+        #currState.AddState('volt_lim_a', self.GetVoltageLimit('A'))
+        #currState.AddState('res_a', self.GetResistance('A'))
         return currState
 
     def SetState(self, state):
@@ -44,10 +44,11 @@ class smu_keithley2400(instruments.instr_VISA):
 
         """
         self.SetOutput(state['output_a'], 'A', verbose=True)
-        self.SetVoltage(state['volt_a'], 'A', verbose=True)
-        self.SetCurrent(state['curr_a'], 'A', verbose=True)
-        self.SetCurrentLimit(state['curr_lim_a'], 'A', verbose=True)
-        self.SetVoltageLimit(state['volt_lim_a'], 'A', verbose=True)
+        self.SetAutoOhmMode(state['auto_ohm_mode'])
+        #self.SetVoltage(state['volt_a'], 'A', verbose=True)
+        #self.SetCurrent(state['curr_a'], 'A', verbose=True)
+        #self.SetCurrentLimit(state['curr_lim_a'], 'A', verbose=True)
+        #self.SetVoltageLimit(state['volt_lim_a'], 'A', verbose=True)
 
     def reset(self, verbose=False):
         """
@@ -59,9 +60,26 @@ class smu_keithley2400(instruments.instr_VISA):
         self.addr.write(":STAT:QUEUE:CLEAR")
         self.addr.write("*RST")
         self.addr.write(":STAT:PRES")
-        self.addr.write(":*CLS")
+        self.addr.write(":SYST:PRES")
+        self.addr.write(":*CLS; *WAI")
+
+        # Disable Auto-Ohm Mode if on. (Prevents GetState)
+        self.SetAutoOhmMode(False)
+        self.SetOutput(False)
+
         if verbose:
             print('Reseting the Keithley Source Measure Unit instrument. . .')
+
+
+    def SetAutoOhmMode(self, state, chan='A', verbose=False, wait=False):
+        if state == True:
+            self.addr.write(":RES:MODE AUTO")
+        else:
+            self.addr.write(":RES:MODE MAN")
+
+    def GetAutoOhmMode(self):
+        status = self.addr.query(':res:mode?')
+        return status
 
     def SetVoltageMode(self, chan='A', verbose=False, wait=False):
         """
@@ -165,6 +183,13 @@ class smu_keithley2400(instruments.instr_VISA):
         None.
 
         """
+        if status == True:
+            status = 1
+        elif status == False:
+            status = 0
+        else:
+            raise ValueError('Incorrect Input type, rtfm')
+
         if chan == 'A':
             self.addr.write(f":OUTP1 {status}")
             if wait or verbose:
@@ -188,7 +213,7 @@ class smu_keithley2400(instruments.instr_VISA):
 
         """
         if chan == 'A':
-            self.SetVoltageMode(chan)
+            #self.SetVoltageMode(chan)
             volt = float(self.addr.query("READ?"))
             return volt
 
@@ -236,7 +261,7 @@ class smu_keithley2400(instruments.instr_VISA):
 
         """
         if chan == 'A':
-            self.SetVoltageMode(chan)
+            # self.SetVoltageMode(chan)
             curr = float(self.addr.query("READ?"))
             return curr
 
@@ -385,7 +410,6 @@ class smu_keithley2400(instruments.instr_VISA):
 
 
 
-
     def GetBeeperState(self):
         return self.addr.query(':SYST:BEEP:STATE?')
     
@@ -409,3 +433,25 @@ class smu_keithley2400(instruments.instr_VISA):
         """
 
         self.addr.write(f':SYST:BEEP:IMM {freq},{time}')
+
+
+    def GetConcurrentMode(self):
+        return (self.addr.query(':FUNC:CONC?'))
+    
+    def SetConcurrentMode(self, state):
+        """
+        Manual:
+        When concurrent measurements are enabled, these commands are used
+        to enable or disable functions to be measured. The [:ON] command is
+        used to include (enable) one or more measurement functions in the list,
+        and the :OFF command is used to remove (disable) one or more func-
+        tions from the list.
+        """
+        if state == True:
+            self.addr.write(':FUNC:CONC ON')
+            self.addr.write(':FUNCtion "VOLTage", "CURRent", "RESistance"')
+        elif state == False:
+            self.addr.write(':FUNC:CONC OFF')
+
+
+

--- a/siepiclab/sequences/onchipLDtoPD/__init__.py
+++ b/siepiclab/sequences/onchipLDtoPD/__init__.py
@@ -1,3 +1,4 @@
+# %%
 """
 SiEPIClab measurement sequence.
 
@@ -28,18 +29,16 @@ class onchipLDtoPD(measurements.sequence):
     def __init__(self, ldc, smu):
         super(onchipLDtoPD, self).__init__()
 
-        #self.ldc = ldc
-        #self.smu = smu
-        self.ldc = ldc_srs_ldc500()
-        self.smu = smu_keithley2400()
+        self.ldc = ldc
+        self.smu = smu
 
-
+        # Default Settings: LDC
         self.Imin = 0
-        self.Imax = 10
-        self.numPts = 2 + 1
-
-        # Default Settings:
-        self.v_bias = -1              # Volts:
+        self.Imax = 20
+        self.numPts = 5 + 1
+        
+        # Default Settings: SMU
+        self.v_bias = -1            # Volts:
         self.i_compliance = 10e-3   # Amps:
 
         # Lab Setup:
@@ -48,7 +47,12 @@ class onchipLDtoPD(measurements.sequence):
 
     def InstrSetting(self):
     
+        smu.reset()
+
         # Set the Reverse Bias Voltage and the Compliance Current:
+        self.smu.SetCurrentMode()
+
+        #self.smu.
         self.smu.SetVoltage(self.v_bias)
         self.smu.SetCurrentLimit(self.i_compliance)
 
@@ -70,11 +74,19 @@ class onchipLDtoPD(measurements.sequence):
         
         ld_currents=[]
         ld_voltages=[]
-    
 
+        pd_currents=[]
+        pd_voltages=[]
+    
+        # Turn On Equipment:
         if self.verbose:
             print('***Activating TEC...***')
         self.ldc.tecON()
+        
+        if self.verbose:
+            print('***Activating SMU...***')
+        self.smu.SetOutput(True)
+        
         if self.verbose:
             print('***Activating LD and Beginning Current Sweep...***')
         self.ldc.LDON()
@@ -82,34 +94,97 @@ class onchipLDtoPD(measurements.sequence):
 
         for ii, II in enumerate(currentsSet):
             self.ldc.SetLDcurrent(II)
-            sleep(2)
+            sleep(1)
             pd_currents = np.append(pd_currents, self.smu.GetCurrent())
-            pd_voltages = np.append(pd_voltages, self.smu.GetCurrent())
+            pd_voltages = np.append(pd_voltages, self.v_bias)
             
             ld_currents = np.append(ld_currents,self.ldc.GetLDcurrent())
             ld_voltages = np.append(ld_voltages,self.ldc.GetLDvoltage())
                 
         if self.verbose:
-            print('***Turning Off LD:***')
+            print('***Turning Off:***')
         self.ldc.SetLDcurrent(0)
         self.ldc.LDOFF()
+        self.smu.SetOutput(False)
+
+        sweepdata = measurements.results()
 
 
-        self.results.add('pd_currents', pd_currents)
-        self.results.add('pd_voltages', pd_voltages)
-        self.results.add('ld_currents', ld_currents)
-        self.results.add('ld_voltages', ld_voltages)
+        sweepdata.add('pd_currents', pd_currents)
+        sweepdata.add('pd_voltages', pd_voltages)
 
+        sweepdata.add('ld_currents', ld_currents)
+        sweepdata.add('ld_voltages', ld_voltages)
 
+        self.results.add('sweepdata', sweepdata)
 
-if __name__ == '__main___':
+print('Hello World')
+
+if __name__ == '__main__':
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    from datetime import datetime
+
     rm = visa.ResourceManager()
 
 
-    ldc = ldc_srs_ldc500(rm.open_resource('GPIB0::20::INSTR'))
-    smu = smu_keithley2400(rm.open_resource('GPIB0::20::INSTR'))
+    ldc = ldc_srs_ldc500(rm.open_resource('ldc'))
+    smu = smu_keithley2400(rm.open_resource('smu'))
 
     print(smu.identify())
     print(ldc.identify())
     
+
+    
+    
+    
+    
     sequence = onchipLDtoPD(ldc, smu)
+    sequence.verbose = True
+
+    # Setup the Sequence:
+    test = False
+    if test:
+        # Sanity Check
+        sequence.Imin = 0
+        sequence.Imax = 10
+        sequence.numPts = 3 + 1
+
+    else:
+        #Normal Settings
+        sequence.Imin = 0
+        sequence.Imax = 50
+        sequence.numPts = 200 + 1
+
+    sequence.v_bias = 1             # Volts:
+    sequence.i_compliance = 10e-3   # Amps:
+
+    sequence.execute()
+    
+    date = datetime.now().strftime("%y-%m-%d_%H-%M-%S")
+    experiment_name = 'LDC-CurrentSweep_SMU-VoltageBias'
+    
+    measID = f'ARL_onchipIntegration_Sweep-{sequence.Imin}-{sequence.Imax}mA_Bias-{sequence.v_bias}V'
+    basedir = 'C:\\Users\\dream\\OneDrive\\Documents\\dp_experiments\\ARL_onChipIntegration'
+    savedir = basedir + '\\' + measID + '\\' + date + '\\'
+    
+    filename = savedir + measID
+    sequence.results.createDir(savedir)
+
+    measID = measID + '_hires'
+
+    # Get the Data from the Sweep:
+    sweepdata = sequence.results.data['sweepdata'].data
+
+    # Save to CSV
+    df = pd.DataFrame(sweepdata)    
+    df.to_csv(filename + '.csv')
+    
+    # Plot and save as PNG
+    fig, ax = plt.subplots(1,1)
+    ax.plot(sweepdata['ld_currents'], 1e3*sweepdata['pd_currents'])
+    ax.set_ylabel("PD Current mA")
+    ax.set_xlabel("LD Current mA")
+    fig.savefig(filename + '_plot.png')
+# %%

--- a/siepiclab/sequences/onchipLDtoPD/__init__.py
+++ b/siepiclab/sequences/onchipLDtoPD/__init__.py
@@ -14,11 +14,11 @@ LDC  -(elec probes)->   DUT [LD to PWB to waveguide to PD] -(elec probes)-> SMU
 import pyvisa as visa
 from siepiclab import measurements
 
-from siepiclab.drivers import ldc_srs_ldc500
-from siepiclab.drivers import smu_keithley2400
+from siepiclab.drivers.ldc_srs_ldc500 import ldc_srs_ldc500
+from siepiclab.drivers.smu_keithley2400 import smu_keithley2400
 
-
-
+from time import sleep
+import numpy as np
 
 class onchipLDtoPD(measurements.sequence):
     """
@@ -28,8 +28,77 @@ class onchipLDtoPD(measurements.sequence):
     def __init__(self, ldc, smu):
         super(onchipLDtoPD, self).__init__()
 
-        self.ldc = ldc
-        self.smu = smu
+        #self.ldc = ldc
+        #self.smu = smu
+        self.ldc = ldc_srs_ldc500()
+        self.smu = smu_keithley2400()
+
+
+        self.Imin = 0
+        self.Imax = 10
+        self.numPts = 2 + 1
+
+        # Default Settings:
+        self.v_bias = -1              # Volts:
+        self.i_compliance = 10e-3   # Amps:
+
+        # Lab Setup:
+        self.instruments = [ldc, smu]
+        self.experiment = measurements.lab_setup(self.instruments)
+
+    def InstrSetting(self):
+    
+        # Set the Reverse Bias Voltage and the Compliance Current:
+        self.smu.SetVoltage(self.v_bias)
+        self.smu.SetCurrentLimit(self.i_compliance)
+
+        # Set the TEC Beta and Ro Values:
+        # TODO
+        
+        # 
+         
+        pass
+
+
+    def instructions(self):
+        
+        if self.verbose:
+            print('*** Setting Up Instrument: ***\n')
+        self.InstrSetting()
+
+        currentsSet=np.linspace(self.Imin,self.Imax,self.numPts)
+        
+        ld_currents=[]
+        ld_voltages=[]
+    
+
+        if self.verbose:
+            print('***Activating TEC...***')
+        self.ldc.tecON()
+        if self.verbose:
+            print('***Activating LD and Beginning Current Sweep...***')
+        self.ldc.LDON()
+        sleep(5)
+
+        for ii, II in enumerate(currentsSet):
+            self.ldc.SetLDcurrent(II)
+            sleep(2)
+            pd_currents = np.append(pd_currents, self.smu.GetCurrent())
+            pd_voltages = np.append(pd_voltages, self.smu.GetCurrent())
+            
+            ld_currents = np.append(ld_currents,self.ldc.GetLDcurrent())
+            ld_voltages = np.append(ld_voltages,self.ldc.GetLDvoltage())
+                
+        if self.verbose:
+            print('***Turning Off LD:***')
+        self.ldc.SetLDcurrent(0)
+        self.ldc.LDOFF()
+
+
+        self.results.add('pd_currents', pd_currents)
+        self.results.add('pd_voltages', pd_voltages)
+        self.results.add('ld_currents', ld_currents)
+        self.results.add('ld_voltages', ld_voltages)
 
 
 
@@ -42,3 +111,5 @@ if __name__ == '__main___':
 
     print(smu.identify())
     print(ldc.identify())
+    
+    sequence = onchipLDtoPD(ldc, smu)

--- a/siepiclab/sequences/onchipLDtoPD/__init__.py
+++ b/siepiclab/sequences/onchipLDtoPD/__init__.py
@@ -1,0 +1,44 @@
+"""
+SiEPIClab measurement sequence.
+
+On-Chip Laser Diode to On-Chip Photodiode (e.g. AIM, GF) Measurement Sequence.
+
+Davin Birdi, 2024
+
+
+# Experiment Setup:
+LDC  -(elec probes)->   DUT [LD to PWB to waveguide to PD] -(elec probes)-> SMU
+
+
+"""
+import pyvisa as visa
+from siepiclab import measurements
+
+from siepiclab.drivers import ldc_srs_ldc500
+from siepiclab.drivers import smu_keithley2400
+
+
+
+
+class onchipLDtoPD(measurements.sequence):
+    """
+    LD Biasing and PD Readout Sequence
+    """
+    
+    def __init__(self, ldc, smu):
+        super(onchipLDtoPD, self).__init__()
+
+        self.ldc = ldc
+        self.smu = smu
+
+
+
+if __name__ == '__main___':
+    rm = visa.ResourceManager()
+
+
+    ldc = ldc_srs_ldc500(rm.open_resource('GPIB0::20::INSTR'))
+    smu = smu_keithley2400(rm.open_resource('GPIB0::20::INSTR'))
+
+    print(smu.identify())
+    print(ldc.identify())


### PR DESCRIPTION
Beeper Settings were added by me, we are developing on a shared computer and unfortunately I was logged into git with Mustafa's account.


The changes in the driver for the SMU may break other sequences, but I am confused why they were like that in the first place. For example, if you wanted to get current from the SMU as it was standing, i.e. you manually programmed it before connecting, it would automatically shift you into Voltage Mode setting current to 0A. It was giving me a headache for this sequence, and without unit testing I can't guarantee that it won't break other sequences that use this driver.


State settings of measurement upon initialization end up turning on the SMU supplying power immediately, which seems like undesired behaviour.



The Sequence I added works and is working fine, we do need to though standardize the Measurement format in which data is saved.


Will merge onto dev_laserCart branch to allow us to continue working with this code.